### PR TITLE
feat: make output status prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,14 @@ func main() {
 
     // Adjust output format based on verbosity
     if verbose > 0 {
-        result.Format = "%s - %s | %s"
+        result.Format = "%s: %s | %s"
     } else {
-        result.Format = "%s - %s"
+        result.Format = "%s: %s"
     }
+
+    // Disable the status prefix if the message already carries its own,
+    // e.g. to avoid doubling an "OK: ..." self-prefix.
+    // result.StatusPrefix = false
 
     // Output the result and exit with the appropriate exit code
     result.SendResult()
@@ -236,7 +240,7 @@ func main() {
     loadAvg, err := getLoadAverage()
     if err != nil {
         result := gomonitor.NewCheckResult()
-        result.SetResult(gomonitor.Unknown, fmt.Sprintf("UNKNOWN: %s", err))
+        result.SetResult(gomonitor.Unknown, fmt.Sprintf("%s", err))
         result.SendResult()
     }
 
@@ -245,13 +249,13 @@ func main() {
 
     if loadAvg > criticalThreshold {
         state = gomonitor.Critical
-        statusMsg = fmt.Sprintf("CRITICAL: Load average %.2f is above critical threshold %.2f", loadAvg, criticalThreshold)
+        statusMsg = fmt.Sprintf("Load average %.2f is above critical threshold %.2f", loadAvg, criticalThreshold)
     } else if loadAvg > warningThreshold {
         state = gomonitor.Warning
-        statusMsg = fmt.Sprintf("WARNING: Load average %.2f is above warning threshold %.2f", loadAvg, warningThreshold)
+        statusMsg = fmt.Sprintf("Load average %.2f is above warning threshold %.2f", loadAvg, warningThreshold)
     } else {
         state = gomonitor.OK
-        statusMsg = fmt.Sprintf("OK: Load average %.2f is below thresholds (warning=%.2f, critical=%.2f)", loadAvg, warningThreshold, criticalThreshold)
+        statusMsg = fmt.Sprintf("Load average %.2f is below thresholds (warning=%.2f, critical=%.2f)", loadAvg, warningThreshold, criticalThreshold)
     }
 
     result := gomonitor.NewCheckResult()
@@ -270,9 +274,9 @@ func main() {
 
     // Adjust output format based on verbosity
     if verbose > 0 {
-        result.Format = "%s - %s | %s"
+        result.Format = "%s: %s | %s"
     } else {
-        result.Format = "%s - %s"
+        result.Format = "%s: %s"
     }
 
     // Output the result and exit with the appropriate exit code
@@ -308,6 +312,7 @@ type CheckResult struct {
     PerfOrder       []string
     PerformanceData map[string]gomonitor.PerformanceMetric
     Format          string
+    StatusPrefix    bool // true by default; set false to omit the status prefix
 }
 ```
 

--- a/gomonitor.go
+++ b/gomonitor.go
@@ -91,16 +91,20 @@ type PerformanceMetric struct {
 }
 
 // CheckResult represents the result of a Monitoring check.
-// - `ExitCode` is the exit code of the check, indicating the status of the check.
-// - `Message` is a descriptive message associated with the check result.
-// - `PerformanceData` is a map containing performance metrics associated with the check result.
-// - `Format` is the format string used to generate the output message.
+//   - `ExitCode` is the exit code of the check, indicating the status of the check.
+//   - `Message` is a descriptive message associated with the check result.
+//   - `PerformanceData` is a map containing performance metrics associated with the check result.
+//   - `Format` is the format string used to generate the output message.
+//   - `StatusPrefix` controls whether the exit code (e.g. "OK") is prepended to the output.
+//     It defaults to true. Set it to false when the message already carries its own status
+//     prefix to avoid doubling (e.g. "OK: CPU usage...").
 type CheckResult struct {
 	ExitCode
 	Message         string
 	PerfOrder       []string
 	PerformanceData map[string]PerformanceMetric
 	Format          string
+	StatusPrefix    bool
 	// Map to store indices of performance metrics for efficient deletion
 	perfIndexMap map[string]int
 }
@@ -159,7 +163,12 @@ func (cr *CheckResult) DeletePerformanceData(metricName string) {
 // FormatResult formats the check result message with performance data, but does not exit the program.
 // This allows for more flexible usage of the library.
 func (cr *CheckResult) FormatResult() string {
-	output := fmt.Sprintf(cr.Format, cr.ExitCode.String(), cr.Message)
+	var output string
+	if cr.StatusPrefix {
+		output = fmt.Sprintf(cr.Format, cr.ExitCode.String(), cr.Message)
+	} else {
+		output = cr.Message
+	}
 
 	// Check if there is performance data to return
 	if len(cr.PerformanceData) > 0 {
@@ -190,7 +199,8 @@ func (cr *CheckResult) SendResult() {
 func NewCheckResult() *CheckResult {
 	return &CheckResult{
 		ExitCode:        OK,
-		Format:          "%s - %s",
+		Format:          "%s: %s",
+		StatusPrefix:    true,
 		PerformanceData: make(map[string]PerformanceMetric),
 		PerfOrder:       []string{},
 		perfIndexMap:    make(map[string]int),

--- a/gomonitor_test.go
+++ b/gomonitor_test.go
@@ -210,6 +210,50 @@ func TestFormatResult(t *testing.T) {
 	}
 }
 
+func TestFormatResult_DefaultFormatPrefix(t *testing.T) {
+	testCases := []struct {
+		name string
+		code ExitCode
+		want string
+	}{
+		{name: "OK", code: OK, want: "OK: Everything is fine"},
+		{name: "Warning", code: Warning, want: "Warning: Everything is fine"},
+		{name: "Critical", code: Critical, want: "Critical: Everything is fine"},
+		{name: "Unknown", code: Unknown, want: "Unknown: Everything is fine"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCheckResult()
+			r.SetResult(tc.code, "Everything is fine")
+
+			if got := r.FormatResult(); got != tc.want {
+				t.Errorf("FormatResult got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatResult_StatusPrefixDisabled(t *testing.T) {
+	r := NewCheckResult()
+	r.StatusPrefix = false
+	r.SetResult(OK, "OK: Everything is fine")
+
+	if got := r.FormatResult(); got != "OK: Everything is fine" {
+		t.Errorf("FormatResult got %q, want %q (no status prefix prepended)", got, "OK: Everything is fine")
+	}
+
+	r2 := NewCheckResult()
+	r2.StatusPrefix = false
+	r2.SetResult(Warning, "High latency")
+	r2.AddPerformanceData("response_time", PerformanceMetric{
+		Value: 1.23, Warn: 1.00, Crit: 2.00, Min: 0.00, Max: 10.00, UnitOM: "ms",
+	})
+	if got := r2.FormatResult(); !containsString(got, "High latency | 'response_time'=1.23") {
+		t.Errorf("FormatResult with perfdata got %q, want to contain %q", got, "High latency | 'response_time'=1.23")
+	}
+}
+
 func TestFormatResult_PerformanceData(t *testing.T) {
 	r := NewCheckResult()
 	r.SetResult(OK, "Check passed")


### PR DESCRIPTION
Change the default output format from '%s - %s' to the Nagios/Icinga convention '%s: %s' (single STATUS: prefix). Add a StatusPrefix field to CheckResult (default true); when set to false, FormatResult/SendResult emit only the raw message so self-prefixed messages do not produce a doubled status prefix (e.g. 'OK - OK: ...').