### PR TITLE
Add Apache-2.0 NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+gomonitor - Go library for monitoring plugins
+Copyright 2024 David Mabry


### PR DESCRIPTION
Closes #13

## Changes

- Add root-level `NOTICE` file with the standard Apache-2.0 attribution line, matching the copyright in `gomonitor.go` (`Copyright 2024 David Mabry`)

## Notes

- Purely additive documentation — no code/build changes
- Lets downstream aggregators reproduce the NOTICE verbatim to stay compliant with Apache License 2.0 §4(b)

## Verification

- [x] gofmt -l . (clean)
- [x] go vet ./... (clean)
- [x] go mod verify (clean)
- [x] commit GPG-signed (key A5E60D29E9712BDD)