### PR TITLE
fix: make FormatResult safe for literal percent signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ func main() {
     value := getMetricValue() // Implement this function to get your metric value
 
     if value > criticalThreshold {
-        result.SetResult(gomonitor.Critical, "Critical: Value exceeds threshold")
+        result.SetResult(gomonitor.Critical, "Value exceeds threshold")
     } else if value > warningThreshold {
-        result.SetResult(gomonitor.Warning, "Warning: Value above warning threshold")
+        result.SetResult(gomonitor.Warning, "Value above warning threshold")
     } else {
-        result.SetResult(gomonitor.OK, "OK: Value within normal range")
+        result.SetResult(gomonitor.OK, "Value within normal range")
     }
 
     // Add performance data
@@ -175,21 +175,30 @@ func main() {
     }
     result.AddPerformanceData("metric_name", metric)
 
-    // Adjust output format based on verbosity
-    if verbose > 0 {
-        result.Format = "%s: %s | %s"
-    } else {
-        result.Format = "%s: %s"
-    }
-
-    // Disable the status prefix if the message already carries its own,
-    // e.g. to avoid doubling an "OK: ..." self-prefix.
-    // result.StatusPrefix = false
-
     // Output the result and exit with the appropriate exit code
     result.SendResult()
 }
 ```
+
+### Format and Status Prefix
+
+By default, `FormatResult()` prepends the status (e.g. `OK: `) to the message:
+
+```go
+result := gomonitor.NewCheckResult()
+result.SetResult(gomonitor.OK, "Everything is fine")
+fmt.Println(result.FormatResult()) // "OK: Everything is fine"
+```
+
+The `Format` field controls the template used when the status prefix is enabled. It supports two `%s` verbs: the first is replaced with the status string, the second with the message. Any other `%` in the template is preserved literally — no escaping needed:
+
+```go
+result.Format = "[%s] %s (95% sure)"
+result.SetResult(gomonitor.Warning, "High latency")
+fmt.Println(result.FormatResult()) // "[Warning] High latency (95% sure)"
+```
+
+If your message already carries its own status prefix (e.g. `"OK: Everything is fine"`), set `StatusPrefix` to `false` to avoid doubling it. Note that performance data is appended to the output automatically, so you should **not** add a `| %s` verb to your `Format` string.
 
 ### Complete Example: Load Average Check
 
@@ -272,13 +281,6 @@ func main() {
     }
     result.AddPerformanceData("load1", metric)
 
-    // Adjust output format based on verbosity
-    if verbose > 0 {
-        result.Format = "%s: %s | %s"
-    } else {
-        result.Format = "%s: %s"
-    }
-
     // Output the result and exit with the appropriate exit code
     result.SendResult()
 }
@@ -323,7 +325,7 @@ type CheckResult struct {
 - `AddPerformanceData(metricName string, metric PerformanceMetric)` - Adds a performance metric to the check result
 - `UpdatePerformanceData(metricName string, metric PerformanceMetric)` - Updates an existing performance metric
 - `DeletePerformanceData(metricName string)` - Deletes a performance metric from the check result
-- `FormatResult() string` - Formats the check result message with performance data (does not exit)
+- `FormatResult() string` - Formats the check result message with performance data (does not exit). The `Format` template supports two `%s` verbs (status, message); other `%` characters are preserved literally.
 - `SendResult()` - Outputs the formatted message and exits with the appropriate exit code
 
 ### PerformanceMetric

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ result.SetResult(gomonitor.OK, "Everything is fine")
 fmt.Println(result.FormatResult()) // "OK: Everything is fine"
 ```
 
-The `Format` field controls the template used when the status prefix is enabled. It supports two `%s` verbs: the first is replaced with the status string, the second with the message. Any other `%` in the template is preserved literally — no escaping needed:
+The `Format` field controls the template used when the status prefix is enabled. It supports two `%s` verbs: the first is replaced with the status string, the second with the message. Any other `%` in the template is preserved literally — no escaping needed (for backward compatibility, an explicit `%%` still collapses to a single `%`):
 
 ```go
 result.Format = "[%s] %s (95% sure)"
@@ -325,7 +325,7 @@ type CheckResult struct {
 - `AddPerformanceData(metricName string, metric PerformanceMetric)` - Adds a performance metric to the check result
 - `UpdatePerformanceData(metricName string, metric PerformanceMetric)` - Updates an existing performance metric
 - `DeletePerformanceData(metricName string)` - Deletes a performance metric from the check result
-- `FormatResult() string` - Formats the check result message with performance data (does not exit). The `Format` template supports two `%s` verbs (status, message); other `%` characters are preserved literally.
+- `FormatResult() string` - Formats the check result message with performance data (does not exit). The `Format` template supports two `%s` verbs (status, message); other `%` characters are preserved literally, and `%%` collapses to a single `%` for backward compatibility.
 - `SendResult()` - Outputs the formatted message and exits with the appropriate exit code
 
 ### PerformanceMetric

--- a/format_footgun_test.go
+++ b/format_footgun_test.go
@@ -1,0 +1,70 @@
+package gomonitor
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatResult_PercentInMessage ensures messages that contain literal '%'
+// characters (e.g. "CPU 95% usage") pass through unchanged. The message is an
+// argument to the Format template, so stray percents in it must not be
+// interpreted as Sprintf verbs.
+func TestFormatResult_PercentInMessage(t *testing.T) {
+	testCases := []struct {
+		name    string
+		message string
+	}{
+		{name: "single percent", message: "CPU usage is 95%"},
+		{name: "trailing percent", message: "Load average is 99%"},
+		{name: "multiple percents", message: "Disk 90% full, mem 80%"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCheckResult()
+			r.SetResult(OK, tc.message)
+
+			got := r.FormatResult()
+			want := "OK: " + tc.message
+			if got != want {
+				t.Errorf("FormatResult got %q, want %q (message must pass through unchanged)", got, want)
+			}
+		})
+	}
+}
+
+// TestFormatResult_PercentInMessageWithPerfData is the same scenario but with
+// performance data attached, exercising the message + perfdata code path.
+func TestFormatResult_PercentInMessageWithPerfData(t *testing.T) {
+	r := NewCheckResult()
+	r.SetResult(OK, "CPU usage is 95%")
+	r.AddPerformanceData("cpu", PerformanceMetric{Value: 95.0, Warn: 80.0, Crit: 90.0, Min: 0.0, Max: 100.0})
+
+	got := r.FormatResult()
+	for _, want := range []string{"CPU usage is 95%", "'cpu'=95.00"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatResult %q does not contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "%!") {
+		t.Errorf("FormatResult %q contains Sprintf error placeholder %q", got, "%!")
+	}
+}
+
+// TestFormatResult_CustomFormatLiteralPercent reproduces the footgun: a
+// literal (unescaped) "%" in a custom Format must not produce Sprintf
+// placeholder garbage such as "%!s(MISSING)".
+func TestFormatResult_CustomFormatLiteralPercent(t *testing.T) {
+	r := NewCheckResult()
+	r.Format = "[%s] %s (95% sure)"
+	r.SetResult(Warning, "High latency")
+
+	got := r.FormatResult()
+	want := "[Warning] High latency (95% sure)"
+	if got != want {
+		t.Errorf("FormatResult got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "%!") {
+		t.Errorf("FormatResult %q contains Sprintf error placeholder %q", got, "%!")
+	}
+}

--- a/format_footgun_test.go
+++ b/format_footgun_test.go
@@ -51,6 +51,31 @@ func TestFormatResult_PercentInMessageWithPerfData(t *testing.T) {
 	}
 }
 
+// TestFormatResult_CustomFormatEscapedPercent ensures the old "%%" escape
+// hatch still works for backward compatibility with the Sprintf-based
+// implementation: "%%" in a custom Format collapses to a single "%".
+func TestFormatResult_CustomFormatEscapedPercent(t *testing.T) {
+	r := NewCheckResult()
+	r.Format = "[%s] %s (95%%)"
+	r.SetResult(Warning, "High latency")
+
+	if got := r.FormatResult(); got != "[Warning] High latency (95%)" {
+		t.Errorf("FormatResult got %q, want %q", got, "[Warning] High latency (95%)")
+	}
+}
+
+// TestFormatResult_PercentEscapeInMessage ensures "%%" inside the message
+// argument is preserved verbatim — only the template collapses "%%", never
+// the substituted values.
+func TestFormatResult_PercentEscapeInMessage(t *testing.T) {
+	r := NewCheckResult()
+	r.SetResult(OK, "100%% sure")
+
+	if got := r.FormatResult(); got != "OK: 100%% sure" {
+		t.Errorf("FormatResult got %q, want %q", got, "OK: 100%% sure")
+	}
+}
+
 // TestFormatResult_CustomFormatLiteralPercent reproduces the footgun: a
 // literal (unescaped) "%" in a custom Format must not produce Sprintf
 // placeholder garbage such as "%!s(MISSING)".

--- a/gomonitor.go
+++ b/gomonitor.go
@@ -22,6 +22,7 @@ package gomonitor
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // ExitCode represents a Nagios exit code
@@ -162,10 +163,16 @@ func (cr *CheckResult) DeletePerformanceData(metricName string) {
 
 // FormatResult formats the check result message with performance data, but does not exit the program.
 // This allows for more flexible usage of the library.
+//
+// The Format template supports the two verbs used by the default format
+// ("%s: %s"): %s is replaced with the status string, and the second %s is
+// replaced with the message. Any other '%' in the template is preserved
+// literally, so a template such as "[%s] %s (95% sure)" is safe without
+// escaping the percent as "%%".
 func (cr *CheckResult) FormatResult() string {
 	var output string
 	if cr.StatusPrefix {
-		output = fmt.Sprintf(cr.Format, cr.ExitCode.String(), cr.Message)
+		output = formatTemplate(cr.Format, cr.ExitCode.String(), cr.Message)
 	} else {
 		output = cr.Message
 	}
@@ -185,6 +192,29 @@ func (cr *CheckResult) FormatResult() string {
 	}
 
 	return output
+}
+
+// formatTemplate renders the Format template safely. It recognizes only the
+// two verbs used by this library — "%s" for status and "%s" for message —
+// and passes through every other '%' literally (no Sprintf interpretation,
+// so stray percents in a template cannot produce "%!s(MISSING)" garbage).
+func formatTemplate(template, status, message string) string {
+	// Fast path: templates without any percent (other than an escaped "%%")
+	// are returned unchanged, so they cannot accidentally consume arguments.
+	parts := strings.Split(template, "%s")
+	if len(parts) == 1 {
+		return template
+	}
+
+	var b strings.Builder
+	b.WriteString(parts[0])
+	b.WriteString(status)
+	for i := 1; i < len(parts)-1; i++ {
+		b.WriteString(parts[i])
+		b.WriteString(message)
+	}
+	b.WriteString(parts[len(parts)-1])
+	return b.String()
 }
 
 // SendResult outputs the formatted message and exits with the appropriate exit code.

--- a/gomonitor.go
+++ b/gomonitor.go
@@ -168,7 +168,8 @@ func (cr *CheckResult) DeletePerformanceData(metricName string) {
 // ("%s: %s"): %s is replaced with the status string, and the second %s is
 // replaced with the message. Any other '%' in the template is preserved
 // literally, so a template such as "[%s] %s (95% sure)" is safe without
-// escaping the percent as "%%".
+// escaping the percent as "%%". For backward compatibility, an explicit
+// "%%" in the template is still collapsed to a single "%".
 func (cr *CheckResult) FormatResult() string {
 	var output string
 	if cr.StatusPrefix {
@@ -198,12 +199,21 @@ func (cr *CheckResult) FormatResult() string {
 // two verbs used by this library — "%s" for status and "%s" for message —
 // and passes through every other '%' literally (no Sprintf interpretation,
 // so stray percents in a template cannot produce "%!s(MISSING)" garbage).
+// For backward compatibility, a "%%" in the template still collapses to a
+// single "%" (the previous Sprintf escape hatch).
 func formatTemplate(template, status, message string) string {
-	// Fast path: templates without any percent (other than an escaped "%%")
-	// are returned unchanged, so they cannot accidentally consume arguments.
 	parts := strings.Split(template, "%s")
+
+	// Collapse "%%" escapes in the template itself, matching the old
+	// Sprintf-based behavior. Status/message arguments are substituted
+	// afterwards, so percents in user content pass through untouched.
+	for i := range parts {
+		parts[i] = strings.ReplaceAll(parts[i], "%%", "%")
+	}
+
+	// Templates without any verb are returned as-is.
 	if len(parts) == 1 {
-		return template
+		return parts[0]
 	}
 
 	var b strings.Builder


### PR DESCRIPTION
## Summary

`FormatResult()` previously passed the `Format` template through `fmt.Sprintf`, which interpreted any `%` in a custom format string as a format verb. A template like `"[%s] %s (95% sure)"` produced `[Warning] High latency (95%!s(MISSING)ure)`.

This PR replaces the Sprintf call with a small template renderer that:
- Substitutes only the two documented `%s` verbs (status, message)
- Preserves every other `%` literally — no escaping needed
- Still collapses `%%` → `%` for backward compatibility with the old Sprintf escape hatch

Also fixes the README: the verbose-output examples set `Format = "%s: %s | %s"`, but `FormatResult()` already appends performance data — so the third verb was dead weight (and only worked because Sprintf got 2 args for 3 verbs). The self-prefixed messages (`"OK: ..."`) also doubled up with the default status prefix. Examples now use plain messages + the default prefix, with a new **Format and Status Prefix** section documenting the template contract.

## Changes

- `gomonitor.go`: add `formatTemplate` helper; `FormatResult` uses it instead of `fmt.Sprintf`
- `format_footgun_test.go`: new tests covering percent-in-message, literal `%` in custom format, `%%` escape compatibility, and `%%` in message args (not collapsed)
- `README.md`: fix stale `| %s` format examples, add Format/StatusPrefix docs, update API reference

## Compatibility

| Format used | Before | After | Breaking? |
|---|---|---|---|
| Default `"%s: %s"` | `OK: msg` | `OK: msg` | No |
| Custom with only `%s` verbs | identical | identical | No |
| Literal `%` (footgun) | `95%!s(MISSING)ure` | `95% sure` | No (garbage → correct) |
| `%%` escape | `95%` | `95%` | No (kept) |
| Non-`%s` verbs (`%d`, `%.2f`) | garbage | literal text | No (was broken) |
| `StatusPrefix = false` | passthrough | passthrough | No |

## Verification

- `go test ./...` — all pass
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `go mod verify` — clean
- README examples smoke-tested against the fixed library