### PR TITLE
fix: harden result output and add non-exiting exit-code access

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,9 @@ type CheckResult struct {
 - `AddPerformanceData(metricName string, metric PerformanceMetric)` - Adds a performance metric to the check result
 - `UpdatePerformanceData(metricName string, metric PerformanceMetric)` - Updates an existing performance metric
 - `DeletePerformanceData(metricName string)` - Deletes a performance metric from the check result
-- `FormatResult() string` - Formats the check result message with performance data (does not exit). The `Format` template supports two `%s` verbs (status, message); other `%` characters are preserved literally, and `%%` collapses to a single `%` for backward compatibility.
-- `SendResult()` - Outputs the formatted message and exits with the appropriate exit code
+- `FormatResult() string` - Formats the check result message with performance data (does not exit). The `Format` template supports two `%s` verbs (status, message); other `%` characters are preserved literally, and `%%` collapses to a single `%` for backward compatibility. To keep single-line Nagios output well-formed, the message is stripped of newlines and `|`, and performance metric labels/units are stripped of `'`, `;`, `|`, and newlines.
+- `SendResult()` - Outputs the formatted message and exits with the appropriate exit code. **Caution:** `os.Exit` skips deferred cleanup in the calling program; use `ResultCode()` and print `FormatResult()` yourself when deferred functions must run.
+- `ResultCode() int` - Returns the integer exit code for the check result without printing or exiting, so callers can control termination (e.g. let their own defer run) instead of relying on `SendResult()`.
 
 ### PerformanceMetric
 

--- a/gomonitor.go
+++ b/gomonitor.go
@@ -21,6 +21,7 @@ package gomonitor
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 )
@@ -171,11 +172,12 @@ func (cr *CheckResult) DeletePerformanceData(metricName string) {
 // escaping the percent as "%%". For backward compatibility, an explicit
 // "%%" in the template is still collapsed to a single "%".
 func (cr *CheckResult) FormatResult() string {
+	message := sanitizeMessage(cr.Message)
 	var output string
 	if cr.StatusPrefix {
-		output = formatTemplate(cr.Format, cr.ExitCode.String(), cr.Message)
+		output = formatTemplate(cr.Format, cr.ExitCode.String(), message)
 	} else {
-		output = cr.Message
+		output = message
 	}
 
 	// Check if there is performance data to return
@@ -183,8 +185,14 @@ func (cr *CheckResult) FormatResult() string {
 		performanceDataStr := ""
 		for _, key := range cr.PerfOrder {
 			metric := cr.PerformanceData[key]
-			metricStr := fmt.Sprintf("'%s'=%.2f%s;%.2f;%.2f;%.2f;%.2f ",
-				key, metric.Value, metric.UnitOM, metric.Warn, metric.Crit, metric.Min, metric.Max)
+			metricStr := fmt.Sprintf("'%s'=%s%s;%s;%s;%s;%s ",
+				sanitizePerfToken(key),
+				formatPerfFloat(metric.Value),
+				sanitizePerfToken(metric.UnitOM),
+				formatPerfFloat(metric.Warn),
+				formatPerfFloat(metric.Crit),
+				formatPerfFloat(metric.Min),
+				formatPerfFloat(metric.Max))
 			performanceDataStr += metricStr
 		}
 
@@ -193,6 +201,43 @@ func (cr *CheckResult) FormatResult() string {
 	}
 
 	return output
+}
+
+// sanitizeMessage strips characters from a plugin message that would break
+// single-line Nagios output or allow output injection through the message:
+// line breaks and the '|' perfdata separator. Everything after the first '|'
+// is treated as perfdata by Nagios, so a '|' inside a message could forge
+// additional output lines.
+func sanitizeMessage(s string) string {
+	s = strings.ReplaceAll(s, "|", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
+}
+
+// sanitizePerfToken strips characters that would corrupt the Nagios
+// performance-data syntax ('label'=value[UOM];warn;crit;min;max) or allow
+// injection through a metric label or unit of measure. The label is wrapped
+// in single quotes, so a literal quote cannot be escaped; a ';' or '|' would
+// shift the warn/crit fields or start a new perfdata token.
+func sanitizePerfToken(s string) string {
+	s = strings.ReplaceAll(s, "'", "")
+	s = strings.ReplaceAll(s, ";", "")
+	s = strings.ReplaceAll(s, "|", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
+}
+
+// formatPerfFloat renders a perfdata numeric field with two decimal places,
+// or an empty string for non-finite values (NaN, +Inf, -Inf). Printing those
+// literally would emit "NaN"/"+Inf" tokens that corrupt Nagios perfdata
+// parsers; an empty field is valid Nagios syntax (e.g. an undefined threshold).
+func formatPerfFloat(f float64) string {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return ""
+	}
+	return fmt.Sprintf("%.2f", f)
 }
 
 // formatTemplate renders the Format template safely. It recognizes only the
@@ -229,10 +274,23 @@ func formatTemplate(template, status, message string) string {
 
 // SendResult outputs the formatted message and exits with the appropriate exit code.
 // This is a convenience method that combines FormatResult with os.Exit.
+//
+// Note: os.Exit does not run deferred functions, so any cleanup registered
+// with defer in the calling program is skipped. Callers that need deferred
+// cleanup to run should print FormatResult() themselves and exit with the
+// value returned by ResultCode().
 func (cr *CheckResult) SendResult() {
 	output := cr.FormatResult()
 	fmt.Println(output)
-	os.Exit(cr.ExitCode.Int())
+	os.Exit(cr.ResultCode())
+}
+
+// ResultCode returns the integer exit code for the check result, matching
+// what SendResult would pass to os.Exit, but without printing or exiting the
+// program. This lets callers control termination themselves so that deferred
+// functions in their own code still run.
+func (cr *CheckResult) ResultCode() int {
+	return cr.ExitCode.Int()
 }
 
 // NewCheckResult initializes a new check result with default values.

--- a/gomonitor_test.go
+++ b/gomonitor_test.go
@@ -1,6 +1,7 @@
 package gomonitor
 
 import (
+	"math"
 	"os"
 	"os/exec"
 	"strings"
@@ -137,6 +138,30 @@ func TestSendResult(t *testing.T) {
 	}
 }
 
+func TestResultCode(t *testing.T) {
+	testCases := []struct {
+		name string
+		code ExitCode
+		want int
+	}{
+		{"Test OK", OK, 0},
+		{"Test Warning", Warning, 1},
+		{"Test Critical", Critical, 2},
+		{"Test Unknown", Unknown, 3},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCheckResult()
+			r.SetResult(tc.code, "message")
+
+			if got := r.ResultCode(); got != tc.want {
+				t.Errorf("ResultCode got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatResult(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -265,6 +290,65 @@ func TestFormatResult_PerformanceData(t *testing.T) {
 	wantFormat := "'test_metric'=42.50%;30.00;50.00;0.00;100.00"
 	if !containsString(output, wantFormat) {
 		t.Errorf("Performance data format incorrect.\nGot: %s\nExpected substring: %s", output, wantFormat)
+	}
+}
+
+func TestFormatResult_SanitizesPerfData(t *testing.T) {
+	r := NewCheckResult()
+	r.SetResult(OK, "check\nok")
+	r.AddPerformanceData("label|with;bad'\nchar", PerformanceMetric{
+		Value: 1.0, Warn: 2.0, Crit: 3.0, Min: 0.0, Max: 10.0, UnitOM: "ms;injected",
+	})
+
+	got := r.FormatResult()
+
+	wantLabel := "'labelwithbadchar'=1.00msinjected;2.00;3.00;0.00;10.00"
+	if !strings.Contains(got, wantLabel) {
+		t.Errorf("FormatResult %q does not contain sanitized perfdata %q", got, wantLabel)
+	}
+	if !strings.Contains(got, "checkok") {
+		t.Errorf("FormatResult %q should have stripped newline from message", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("FormatResult %q still contains an unsanitized newline", got)
+	}
+	if strings.Contains(got, "bad'") || strings.Contains(got, ";bad") || strings.Contains(got, "with|") {
+		t.Errorf("FormatResult %q still contains an unsanitized injected delimiter in the label", got)
+	}
+}
+
+func TestFormatResult_NonFinitePerfData(t *testing.T) {
+	testCases := []struct {
+		name   string
+		metric PerformanceMetric
+		want   string
+	}{
+		{
+			name:   "NaN value",
+			metric: PerformanceMetric{Value: math.NaN(), Warn: 2.0, Crit: 3.0, Min: 0.0, Max: 10.0},
+			want:   "'m'=;2.00;3.00;0.00;10.00",
+		},
+		{
+			name:   "Infinity thresholds",
+			metric: PerformanceMetric{Value: 1.0, Warn: math.Inf(1), Crit: math.Inf(-1), Min: 0.0, Max: 10.0},
+			want:   "'m'=1.00;;;0.00;10.00",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCheckResult()
+			r.SetResult(OK, "check")
+			r.AddPerformanceData("m", tc.metric)
+
+			got := r.FormatResult()
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("FormatResult %q does not contain expected perfdata %q", got, tc.want)
+			}
+			if strings.Contains(got, "NaN") || strings.Contains(got, "Inf") {
+				t.Errorf("FormatResult %q contains a non-finite token", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Security/robustness hardening of result output, addressing items from the codebase security review:

1. **os.Exit / defer hazard** — `SendResult()` calls `os.Exit`, which skips deferred cleanup in the enclosing program. Added `ResultCode() int` so callers can retrieve the exit code and terminate themselves (allowing their `defer`s to run). `SendResult()` is unchanged in behavior (non-breaking).

2. **Output / perfdata injection** — the plugin message and perfdata labels/units were interpolated unsanitized, so `|`, `;`, `'`, and newlines could corrupt Nagios parsing or forge additional output lines. Added `sanitizeMessage()` (strips `|`, CR/LF) and `sanitizePerfToken()` (strips `'`, `;`, `|`, CR/LF).

3. **NaN/Inf perfdata tokens** — `%.2f` emitted literal `NaN`/`+Inf` into perfdata, corrupting parsers. `formatPerfFloat()` now emits an empty field for non-finite values (valid Nagios syntax for an undefined threshold).

## Changes

- Add `ResultCode() int` (new, non-breaking accessor)
- Sanitize message + perfdata label/unit output
- Render non-finite perfdata fields as empty
- Table-driven tests for all three behaviors
- README updates documenting the new method and sanitization

Non-breaking: backward compatible, patch/minor level; no `/v2` import-path change.